### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ git clone git@github.com:simpleapples/pdf2word.git
 
 ```python
 cd pdf2word
-pyvenv venv
-source venv/bin/active
+python3 -m venv venv  
+source venv/bin/activate
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
激活的命令拼写错了 应该为 source venv/bin/activate