### PR TITLE
fix dependence error for pdfminer3k

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 attrs==17.4.0
 lxml==4.1.1
-pdfminer3k==1.3.1
+pdfminer3k==1.3.2
 pluggy==0.6.0
 ply==3.11
 py==1.5.2


### PR DESCRIPTION
fix follow error:
Collecting pdfminer3k==1.3.1 (from -r requirements.txt (line 3))
  Could not find a version that satisfies the requirement pdfminer3k==1.3.1 (from -r requirements.txt (line 3)) (from versions: 1.3.2, 1.3.3, 1.3.4)                                              
No matching distribution found for pdfminer3k==1.3.1 (from -r requirements.txt (line 3))
